### PR TITLE
Fix testcases targeting F29

### DIFF
--- a/src/test/java/client/OSDetectionTests.java
+++ b/src/test/java/client/OSDetectionTests.java
@@ -1,40 +1,44 @@
 package client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import client.OSDetection.OS;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 
 /**
  * @author edvintopa
- * @project project-course-2
- * @created 2024-02-20
+ * @author Johannes Rosengren
  */
-class OSDetectionTest {
+public class OSDetectionTests {
 
-  /*
-   * ONLY ONE OF THESE ARE SUPPOSED TO PASS
-   */
   @Test
-  void getOS_Mac() {
+  @EnabledOnOs(org.junit.jupiter.api.condition.OS.MAC)
+  public void getOS_Mac() {
     OSDetection.OS expectedOS = OS.MAC;
     OSDetection.OS actualOS = OSDetection.getOS();
 
     assertEquals(expectedOS, actualOS);
   }
+
   @Test
-  void getOS_Windows() {
+  @EnabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
+  public void getOS_Windows() {
     OSDetection.OS expectedOS = OS.WINDOWS;
     OSDetection.OS actualOS = OSDetection.getOS();
 
     assertEquals(expectedOS, actualOS);
   }
-
+  
   @Test
-  void getOS_Unsupported() {
+  @DisabledOnOs({org.junit.jupiter.api.condition.OS.MAC,
+      org.junit.jupiter.api.condition.OS.WINDOWS})
+  public void getOS_Unsupported() {
     OSDetection.OS expectedOS = OS.UNSUPPORTED;
     OSDetection.OS actualOS = OSDetection.getOS();
 
     assertEquals(expectedOS, actualOS);
   }
+
 }

--- a/src/test/java/client/OSDetectionTests.java
+++ b/src/test/java/client/OSDetectionTests.java
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
  */
 public class OSDetectionTests {
 
+  /**
+   * Requirements: F29
+   */
   @Test
   @EnabledOnOs(org.junit.jupiter.api.condition.OS.MAC)
   public void getOS_Mac() {
@@ -22,6 +25,9 @@ public class OSDetectionTests {
     assertEquals(expectedOS, actualOS);
   }
 
+  /**
+   * Requirements: F29
+   */
   @Test
   @EnabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
   public void getOS_Windows() {
@@ -30,7 +36,10 @@ public class OSDetectionTests {
 
     assertEquals(expectedOS, actualOS);
   }
-  
+
+  /**
+   * Requirements: F29
+   */
   @Test
   @DisabledOnOs({org.junit.jupiter.api.condition.OS.MAC,
       org.junit.jupiter.api.condition.OS.WINDOWS})


### PR DESCRIPTION
- Make platform specific tests run only on target platforms
- Add target requirements for unit tests as comments